### PR TITLE
Expand support for Linux. It should now point to the correct location…

### DIFF
--- a/EDScoutCore/EDSMInterface.py
+++ b/EDScoutCore/EDSMInterface.py
@@ -1,11 +1,18 @@
 import requests
 import requests_cache
 import os
+import platform
 
 # See https://www.edsm.net/en_GB/api-v1
 
 # Setup the cache directory in the user area.
-cache_path = os.path.join(os.path.expanduser('~'), 'AppData', 'Local', 'EDScout')
+osname = platform.system()
+if  osname == 'Windows':
+    cache_path = os.path.join(os.path.expanduser('~'), 'AppData', 'Local', 'EDScout')
+elif osname == 'Linux':
+    cache_path = os.path.join(os.path.expanduser('~'), '.local', 'share', 'EDScout')
+else:
+    raise Exception(f"EDScout does not support {osname}")
 os.makedirs(cache_path, exist_ok=True)
 cache_name = 'edsm_cache'
 requests_cache.install_cache(os.path.join(cache_path, cache_name))

--- a/EDScoutCore/OutputRecorder.py
+++ b/EDScoutCore/OutputRecorder.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 from pathlib import Path
 from datetime import datetime
 
@@ -7,7 +8,14 @@ from datetime import datetime
 class OutputRecorder:
 
     def __init__(self, file_name_prefix):
-        recording_dir = os.path.join(os.path.expanduser('~'), 'AppData', 'Local', 'EDScout', 'StreamRecords')
+        osname = platform.system()
+        if osname == 'Windows':
+            recording_dir = os.path.join(os.path.expanduser('~'), 'AppData', 'Local', 'EDScout', 'StreamRecords')
+        elif osname == 'Linux':
+            recording_dir = os.path.join(os.path.expanduser('~'), '.local', 'share', 'EDScout', 'StreamRecords')
+        else:
+            raise Exception(f"EDScout does not support {osname}")
+
         if not os.path.isdir(recording_dir):
             Path(recording_dir).mkdir(parents=True, exist_ok=True)
         timestamp = datetime.utcnow().strftime('%Y-%m-%d-%H-%M-%S')

--- a/EDScoutCore/SavedGamesLocator.py
+++ b/EDScoutCore/SavedGamesLocator.py
@@ -1,8 +1,11 @@
 
 
 import os
-import winreg
+import platform
 
+osname = platform.system()
+if osname == 'Windows':
+    import winreg
 
 def get_saved_games_path():
     """Returns the default downloads path for linux or windows
@@ -10,14 +13,26 @@ def get_saved_games_path():
     Adapted from this: https://stackoverflow.com/questions/35851281/python-finding-the-users-downloads-folder?lq=1
     """
     save_game_root = None
-    if os.name == 'nt':
+    osname = platform.system()
+    if osname == 'Windows':
         sub_key = r'SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders'
         downloads_guid = '{4C5C32FF-BB9D-43b0-B5B4-2D72E54EAAA4}'
         with winreg.OpenKey(winreg.HKEY_CURRENT_USER, sub_key) as key:
             location = winreg.QueryValueEx(key, downloads_guid)[0]
         save_game_root = location
-    else:
-        save_game_root = os.path.join(os.path.expanduser('~'), 'Saved Games')
+    elif osname == 'Linux':
+        save_game_root = os.path.join(os.path.expanduser('~'),
+                                      '.local',
+                                      'share',
+                                      'Steam',
+                                      'steamapps',
+                                      'compatdata',
+                                      '359320',
+                                      'pfx',
+                                      'drive_c',
+                                      'users',
+                                      'steamuser',
+                                      'Saved Games')
 
     return os.path.join(save_game_root, "Frontier Developments", "Elite Dangerous")
 

--- a/EDScoutWebUI/EDScout.py
+++ b/EDScoutWebUI/EDScout.py
@@ -4,6 +4,7 @@ import sys
 import logging
 import argparse
 import tempfile
+import platform
 import psutil
 import time
 from datetime import datetime
@@ -73,7 +74,13 @@ def configure_logger(logger_to_configure, log_path, log_level_override=None):
 
 
 # Work out where to stick the logs and make sure it exists
-logging_dir = os.path.join(os.path.expanduser('~'), 'AppData', 'Local', 'EDScout', 'Logs')
+osname = platform.system()
+if osname == 'Windows':
+    logging_dir = os.path.join(os.path.expanduser('~'), 'AppData', 'Local', 'EDScout', 'Logs')
+elif osname == 'Linux':
+    logging_dir = os.path.join(os.path.expanduser('~'), '.local', 'share', 'EDScout', 'logs')
+else:
+    raise Exception(f"EDScout does not support {osname}")
 if not os.path.isdir(logging_dir):
     Path(logging_dir).mkdir(parents=True, exist_ok=True)
 timestamp = datetime.utcnow().strftime('%Y-%m-%d-%H-%M-%S')

--- a/EDScoutWebUI/HudColourAdjuster.py
+++ b/EDScoutWebUI/HudColourAdjuster.py
@@ -1,8 +1,32 @@
 import xml.etree.ElementTree as ET
 import re
 import os
+import platform
 
-default_config_file = os.path.join(os.path.expanduser('~'), r"AppData\Local\Frontier Developments\Elite Dangerous\Options\Graphics\GraphicsConfigurationOverride.xml")
+osname = platform.system()
+if osname == 'Windows':
+    default_config_file = os.path.join(os.path.expanduser('~'), r"AppData\Local\Frontier Developments\Elite Dangerous\Options\Graphics\GraphicsConfigurationOverride.xml")
+elif osname == 'Linux':
+    default_config_file = os.path.join(os.path.expanduser('~'),
+                                       ".local",
+                                       "share",
+                                       "Steam",
+                                       "steamapps",
+                                       "compatdata",
+                                       "359320",
+                                       "pfx",
+                                       "drive_c",
+                                       "users",
+                                       "steamuser",
+                                       "Local Settings",
+                                       "Application Data",
+                                       "Frontier Developments",
+                                       "Elite Dangerous",
+                                       "Options",
+                                       "Graphics",
+                                       "GraphicsConfigurationOverride.xml")
+else:
+    raise Exception(f"EDScout does not support {osname}")
 # print(f'default_config_file={default_config_file}')
 
 # Worked out the transform from here:


### PR DESCRIPTION
Here is a first attempt to fix issue #100 . EDScout should point to the right files in a Steam/Proton install. In addition the EDScout files themselves are stored in a more natural location (that location could be improved using the XDG environment variables for non-standard installations). It appears to work for me, but I cannot test under Windows so let me know in case I broke Windows support.